### PR TITLE
Enable AndroidLocationProvider after adding any location update listeners

### DIFF
--- a/app/src/main/java/com/tomtom/sdk/examples/usecase/BasicNavigationActivity.kt
+++ b/app/src/main/java/com/tomtom/sdk/examples/usecase/BasicNavigationActivity.kt
@@ -176,7 +176,6 @@ class BasicNavigationActivity : AppCompatActivity() {
      * Read more about user location on the map in the Showing User Location guide.
      */
     private fun showUserLocation() {
-        locationProvider.enable()
         // zoom to current location at city level
         onLocationUpdateListener = OnLocationUpdateListener { location ->
             tomTomMap.moveCamera(CameraOptions(location.position, zoom = 8.0))
@@ -186,6 +185,7 @@ class BasicNavigationActivity : AppCompatActivity() {
         tomTomMap.setLocationProvider(locationProvider)
         val locationMarker = LocationMarkerOptions(type = LocationMarkerOptions.Type.Pointer)
         tomTomMap.enableLocationMarker(locationMarker)
+        locationProvider.enable()
     }
 
     /**


### PR DESCRIPTION
A location update is emitted as soon as the location provider is enabled however the next location update is emitted, presumably, when the underlying location source provides an update (which will vary by implementation of the LocationProvider interface).

In the current implementation of the showUserLocation() method the location provider is enabled before the location marker has been enabled for the map and the one-time location update listener has been registered that moves the camera to the current user location. This has the effect of delaying the display of the location marker and centering of the map on the user location until the next location update is emitted, which is 6 - 10 seconds on my physical Pixel device and reported to be up to several minutes by a customer.

Moving the enabling of the location provider to the end of the method has the effect of immediately displaying the user location.