### PR TITLE
When creating the TomTomNavigation object set the vehicle to be used for navigation explicitly

### DIFF
--- a/app/src/main/java/com/tomtom/sdk/examples/usecase/BasicNavigationActivity.kt
+++ b/app/src/main/java/com/tomtom/sdk/examples/usecase/BasicNavigationActivity.kt
@@ -61,6 +61,7 @@ import com.tomtom.sdk.routing.options.guidance.InstructionType
 import com.tomtom.sdk.routing.options.guidance.ProgressPoints
 import com.tomtom.sdk.routing.online.OnlineRoutePlanner
 import com.tomtom.sdk.routing.route.Route
+import com.tomtom.sdk.vehicle.DefaultVehicleProvider
 import com.tomtom.sdk.vehicle.Vehicle
 
 /**
@@ -153,6 +154,7 @@ class BasicNavigationActivity : AppCompatActivity() {
             locationProvider = locationProvider,
             routeReplanner = routeReplanner
         )
+        (navigationConfiguration.vehicleProvider as DefaultVehicleProvider).setVehicle(Vehicle.Car())
         tomTomNavigation = TomTomNavigationFactory.create(navigationConfiguration)
     }
 
@@ -382,9 +384,7 @@ class BasicNavigationActivity : AppCompatActivity() {
         val routeGeoLocations = route.geometry.map { GeoLocation(it) }
         val simulationStrategy = InterpolationStrategy(routeGeoLocations)
         locationProvider = SimulationLocationProvider.create(strategy = simulationStrategy)
-        tomTomNavigation.navigationEngineRegistry.updateEngines(
-            locationProvider = locationProvider
-        )
+        tomTomNavigation.locationProvider = locationProvider
         locationProvider.enable()
     }
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,5 +1,5 @@
 ext {
-    gosdkVersion = "0.12.0"
+    gosdkVersion = "0.22.4"
     androidXNavigation = "2.5.3"
     androidXCoreVersion = "1.7.0"
     androidXCompatVersion = "1.4.2"


### PR DESCRIPTION
To ensure that the vehicle type used for route planning is also used for navigation it's necessary to set the vehicle used for the `VehicleProvider` explicitly when creating the `TomTomNavigation` object.