### PR TITLE
fix: use no action bar style instead of the dark action bar

### DIFF
--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,6 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <style name="Theme.NavigatingWithTomTom" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+    <style name="Theme.NavigatingWithTomTom" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/purple_200</item>
         <item name="colorPrimaryVariant">@color/purple_700</item>


### PR DESCRIPTION
Align night styles with the default ones and use `Theme.MaterialComponents.DayNight.NoActionBar` as the parent.