### PR TITLE
feat: create navigation using OfflineTomTomNavigationFactory

### DIFF
--- a/app/src/main/java/com/tomtom/sdk/examples/usecase/offline/OfflineNavigationActivity.kt
+++ b/app/src/main/java/com/tomtom/sdk/examples/usecase/offline/OfflineNavigationActivity.kt
@@ -46,11 +46,10 @@ import com.tomtom.sdk.navigation.NavigationFailure
 import com.tomtom.sdk.navigation.ProgressUpdatedListener
 import com.tomtom.sdk.navigation.RoutePlan
 import com.tomtom.sdk.navigation.TomTomNavigation
-import com.tomtom.sdk.navigation.TomTomNavigationFactory
 import com.tomtom.sdk.navigation.featuretoggle.ExperimentalStandaloneNavigationOrchestrationApi
 import com.tomtom.sdk.navigation.featuretoggle.StandaloneNavigationOrchestrationFeature
-import com.tomtom.sdk.navigation.offline.ExperimentalOfflineNavigationFactory
-import com.tomtom.sdk.navigation.offline.createOfflineNavigation
+import com.tomtom.sdk.navigation.offline.Configuration
+import com.tomtom.sdk.navigation.offline.OfflineTomTomNavigationFactory
 import com.tomtom.sdk.navigation.ui.NavigationFragment
 import com.tomtom.sdk.navigation.ui.NavigationUiOptions
 import com.tomtom.sdk.routing.RoutePlanner
@@ -176,13 +175,14 @@ class OfflineNavigationActivity : AppCompatActivity() {
         routePlanner = OfflineRoutePlanner.create(context = this, ndsStore = ndsStore)
     }
 
-    @OptIn(InternalTomTomSdkApi::class, ExperimentalOfflineNavigationFactory::class)
     private fun initNavigation() {
-        tomTomNavigation = TomTomNavigationFactory.createOfflineNavigation(
-            context = this,
-            locationProvider = locationProvider,
-            ndsStore = ndsStore,
-            routePlanner = routePlanner
+        tomTomNavigation = OfflineTomTomNavigationFactory.create(
+            Configuration(
+                context = this,
+                locationProvider = locationProvider,
+                ndsStore = ndsStore,
+                routePlanner = routePlanner
+            )
         )
     }
 
@@ -308,9 +308,7 @@ class OfflineNavigationActivity : AppCompatActivity() {
 
     private fun setSimulationLocationProviderToNavigation() {
         locationProvider = createSimulationLocationProvider(route!!)
-        tomTomNavigation.navigationEngineRegistry.updateEngines(
-            locationProvider = locationProvider
-        )
+        tomTomNavigation.locationProvider = locationProvider
         locationProvider.enable()
     }
 
@@ -426,7 +424,7 @@ class OfflineNavigationActivity : AppCompatActivity() {
     }
 
     private fun setNdsStorePosition(currentPosition: GeoPoint) {
-        ndsStore.setPosition(currentPosition)
+        ndsStore.updatePosition(currentPosition)
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/com/tomtom/sdk/examples/usecase/online/OnlineNavigationActivity.kt
+++ b/app/src/main/java/com/tomtom/sdk/examples/usecase/online/OnlineNavigationActivity.kt
@@ -369,9 +369,7 @@ class OnlineNavigationActivity : AppCompatActivity() {
         val routeGeoLocations = route.geometry.map { GeoLocation(it) }
         val simulationStrategy = InterpolationStrategy(routeGeoLocations)
         locationProvider = SimulationLocationProvider.create(strategy = simulationStrategy)
-        tomTomNavigation.navigationEngineRegistry.updateEngines(
-            locationProvider = locationProvider
-        )
+        tomTomNavigation.locationProvider = locationProvider
         locationProvider.enable()
     }
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,5 +1,5 @@
 ext {
-    gosdkVersion = "0.12.0"
+    gosdkVersion = "0.24.0"
     androidXNavigation = "2.5.3"
     androidXCoreVersion = "1.7.0"
     androidXCompatVersion = "1.4.2"


### PR DESCRIPTION
Since `TomTomNavigationFactory.createOfflineNavigation(...)` method is removed in future releases, replace it with `OfflineTomTomNavigationFactory.create(...)`.