### PR TITLE
Bump compileSdk, targetSdk, gradle and Android Gradle Plugin

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -12,10 +12,11 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v2
-      - name: SETUP JVM 11
-        uses: actions/setup-java@v1
+      - name: SETUP JVM 17
+        uses: actions/setup-java@v2
         with:
-          java-version: 11
+          distribution: zulu
+          java-version: 17
       - name: Print JVM version
         run: javac -version
       - name: Wrapper permissions

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,12 +5,12 @@ plugins {
 apply from: '../dependencies.gradle'
 
 android {
-    compileSdk 32
+    compileSdk 33
 
     defaultConfig {
         applicationId "com.tomtom.sdk.examples"
         minSdk 24
-        targetSdk 32
+        targetSdk 33
         versionCode 1
         versionName "1.0"
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,6 +5,7 @@ plugins {
 apply from: '../dependencies.gradle'
 
 android {
+    namespace = "com.tomtom.sdk.examples"
     compileSdk 33
 
     defaultConfig {
@@ -42,6 +43,7 @@ android {
     }
     buildFeatures {
         viewBinding true
+        buildConfig true
     }
 
     buildTypes.each {

--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ buildscript {
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.2.1' apply false
-    id 'com.android.library' version '7.2.1' apply false
+    id 'com.android.application' version '8.0.2' apply false
+    id 'com.android.library' version '8.0.2' apply false
     id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Jul 29 14:41:50 CEST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Update the compileSdk and targetSdk versions to 33.
The old gradle version was not compatible, so I updated it as well, together with AGP. Finally, the new gradle version requires java 17.