### PR TITLE
Removing artifactory credentials requirement from the code

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,6 @@ Add the entries below to the global `~/.gradle/gradle.properties` file at `$HOME
 
 ```bash
 
-# required for accessing to artifactory
-repositoryUsername=###
-repositoryIdentityToken=###
-
 # required in order to use TomTom's APIs
 tomtomApiKey = YOUR_API_KEY
 ```

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,14 +10,6 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        maven {
-            credentials {
-                username = repositoryUsername
-                password = repositoryIdentityToken
-            }
-            url = uri("https://repositories.tomtom.com/artifactory/maven")
-
-        }
     }
 }
 rootProject.name = "TomTom SDK Examples"

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,6 +10,9 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven {
+            url = uri("https://repositories.tomtom.com/artifactory/maven")
+        }
     }
 }
 rootProject.name = "TomTom SDK Examples"


### PR DESCRIPTION
I didn't remove the lines from the Github actions. 
Because it uses the "secrets" from the repo.